### PR TITLE
Add as_objects parameter to APIs

### DIFF
--- a/blocket_api/blocket.py
+++ b/blocket_api/blocket.py
@@ -11,7 +11,11 @@ import httpx
 
 from blocket_api.models import (
     CustomSearchResults,
+    HomeSearchResponse,
     MotorSearchResults,
+    PriceEvaluation,
+    SavedSearch,
+    SearchContentResults,
     StoreSearchResults,
 )
 from blocket_api.qasa import HOME_SEARCH_ORDERING, HomeType, OrderBy, Qasa
@@ -181,8 +185,25 @@ def _make_request(
 class BlocketAPI:
     token: str | None = None
 
+    @overload
+    def saved_searches(self, *, as_objects: Literal[True]) -> list[SavedSearch]: ...
+
+    @overload
+    def saved_searches(self, *, as_objects: Literal[False] = False) -> list[dict]: ...
+
+    @overload
+    def saved_searches(
+        self,
+        *,
+        as_objects: bool = False,
+    ) -> list[dict] | list[SavedSearch]: ...
+
     @auth_token
-    def saved_searches(self) -> list[dict]:
+    def saved_searches(
+        self,
+        *,
+        as_objects: bool = False,
+    ) -> list[dict] | list[SavedSearch]:
         """
         Retrieves saved searches data, also known as "Bevakningar".
         """
@@ -201,7 +222,10 @@ class BlocketAPI:
             .get("data", [])
         )
 
-        return searches + mobility_searches
+        combined_searches = searches + mobility_searches
+        if as_objects:
+            return [SavedSearch.model_validate(search) for search in combined_searches]
+        return combined_searches
 
     def _for_search_id(self, search_id: int, limit: int) -> dict:
         assert self.token
@@ -219,8 +243,41 @@ class BlocketAPI:
             return mobility_searches.json()
         return searches.json()
 
+    @overload
+    def get_listings(
+        self,
+        search_id: int | None = ...,
+        limit: int = 99,
+        *,
+        as_objects: Literal[True],
+    ) -> SearchContentResults: ...
+
+    @overload
+    def get_listings(
+        self,
+        search_id: int | None = ...,
+        limit: int = 99,
+        *,
+        as_objects: Literal[False] = False,
+    ) -> dict: ...
+
+    @overload
+    def get_listings(
+        self,
+        search_id: int | None = ...,
+        limit: int = 99,
+        *,
+        as_objects: bool = False,
+    ) -> dict | SearchContentResults: ...
+
     @auth_token
-    def get_listings(self, search_id: int | None = None, limit: int = 99) -> dict:
+    def get_listings(
+        self,
+        search_id: int | None = None,
+        limit: int = 99,
+        *,
+        as_objects: bool = False,
+    ) -> dict | SearchContentResults:
         """
         Retrieve listings/ads based on the provided search criteria.
         """
@@ -230,12 +287,18 @@ class BlocketAPI:
             raise LimitError("Limit cannot be greater than 99.")
 
         if search_id:
-            return self._for_search_id(search_id, limit)
+            response = self._for_search_id(search_id, limit)
+        else:
+            response = _make_request(
+                url=BASE_URL + f"/saved/v2/searches_content?lim={limit}",
+                token=self.token,
+            ).json()
 
-        return _make_request(
-            url=BASE_URL + f"/saved/v2/searches_content?lim={limit}",
-            token=self.token,
-        ).json()
+        return (
+            SearchContentResults.model_validate(response)
+            if as_objects
+            else response
+        )
 
     @overload
     def custom_search(
@@ -389,11 +452,37 @@ class BlocketAPI:
         response = _make_request(url=f"{url}", token=self.token).json()
         return MotorSearchResults.model_validate(response) if as_objects else response
 
+    @overload
+    def price_eval(
+        self,
+        registration_number: str,
+        *,
+        as_objects: Literal[True],
+    ) -> PriceEvaluation: ...
+
+    @overload
+    def price_eval(
+        self,
+        registration_number: str,
+        *,
+        as_objects: Literal[False] = False,
+    ) -> dict: ...
+
+    @overload
+    def price_eval(
+        self,
+        registration_number: str,
+        *,
+        as_objects: bool = False,
+    ) -> dict | PriceEvaluation: ...
+
     @public_token
     def price_eval(
         self,
         registration_number: str,
-    ) -> dict:
+        *,
+        as_objects: bool = False,
+    ) -> dict | PriceEvaluation:
         """
         Price evaluation for a specific vehicle by using cars
         registration number (ABC123).
@@ -401,7 +490,44 @@ class BlocketAPI:
         This is using same api endpoint as https://www.blocket.se/tjanster/vardera-bil.
         """
         url = f"{BYTBIL_URL}/blocket-basedata-api/v3/vehicle-data/{registration_number}"
-        return _make_request(url=f"{url}", token=None).json()
+        response = _make_request(url=f"{url}", token=None).json()
+        return PriceEvaluation.model_validate(response) if as_objects else response
+
+    @overload
+    def home_search(
+        self,
+        city: str,
+        type: HomeType,
+        order_by: OrderBy = OrderBy.published_at,
+        ordering: HOME_SEARCH_ORDERING = "descending",
+        offset: int = 0,
+        *,
+        as_objects: Literal[True],
+    ) -> HomeSearchResponse: ...
+
+    @overload
+    def home_search(
+        self,
+        city: str,
+        type: HomeType,
+        order_by: OrderBy = OrderBy.published_at,
+        ordering: HOME_SEARCH_ORDERING = "descending",
+        offset: int = 0,
+        *,
+        as_objects: Literal[False] = False,
+    ) -> dict: ...
+
+    @overload
+    def home_search(
+        self,
+        city: str,
+        type: HomeType,
+        order_by: OrderBy = OrderBy.published_at,
+        ordering: HOME_SEARCH_ORDERING = "descending",
+        offset: int = 0,
+        *,
+        as_objects: bool = False,
+    ) -> dict | HomeSearchResponse: ...
 
     def home_search(
         self,
@@ -410,19 +536,22 @@ class BlocketAPI:
         order_by: OrderBy = OrderBy.published_at,
         ordering: HOME_SEARCH_ORDERING = "descending",
         offset: int = 0,
-    ) -> dict:
+        *,
+        as_objects: bool = False,
+    ) -> dict | HomeSearchResponse:
         """
         This returns all available home listings available at
         https://bostad.blocket.se/. Specify offset to get next page. Each page contains
         60 items, which is max items returned per api query.
         """
-        return Qasa(
+        response = Qasa(
             city=city,
             home_type=type,
             order_by=order_by,
             ordering=ordering,
             offset=offset,
         ).search()
+        return HomeSearchResponse.model_validate(response) if as_objects else response
 
     @overload
     def search_store(
@@ -473,12 +602,41 @@ class BlocketAPI:
         response = _make_request(url=f"{url}", token=self.token).json()
         return StoreSearchResults.model_validate(response) if as_objects else response
 
+    @overload
+    def get_store_listings(
+        self,
+        store_id: int,
+        page: int = 0,
+        *,
+        as_objects: Literal[True],
+    ) -> SearchContentResults: ...
+
+    @overload
+    def get_store_listings(
+        self,
+        store_id: int,
+        page: int = 0,
+        *,
+        as_objects: Literal[False] = False,
+    ) -> dict: ...
+
+    @overload
+    def get_store_listings(
+        self,
+        store_id: int,
+        page: int = 0,
+        *,
+        as_objects: bool = False,
+    ) -> dict | SearchContentResults: ...
+
     @public_token
     def get_store_listings(
         self,
         store_id: int,
         page: int = 0,
-    ) -> dict:
+        *,
+        as_objects: bool = False,
+    ) -> dict | SearchContentResults:
         """
         Return all listings from a specific store from https://www.blocket.se/butik/<store>.
         The store_id can be found by searching for the store with search_store().
@@ -487,4 +645,9 @@ class BlocketAPI:
             f"{BASE_URL}/search_bff/v2/content?lim=60&page={page}&sort=rel&store_id={store_id}"
             "&status=active&gl=3&include=extend_with_shipping"
         )
-        return _make_request(url=f"{url}", token=self.token).json()
+        response = _make_request(url=f"{url}", token=self.token).json()
+        return (
+            SearchContentResults.model_validate(response)
+            if as_objects
+            else response
+        )

--- a/blocket_api/models.py
+++ b/blocket_api/models.py
@@ -1,6 +1,13 @@
 import datetime
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+
+class BlocketBaseModel(BaseModel):
+    """Base model that allows unknown fields from the Blocket APIs."""
+
+    model_config = ConfigDict(extra="allow")
 
 ### CustomSearch ###
 
@@ -149,3 +156,108 @@ class StoreSearchResults(BaseModel):
     data: list[StoreSearchResult]
     total_count: int
     total_page_count: int
+
+
+### Saved searches ###
+
+
+class SavedSearch(BlocketBaseModel):
+    id: str
+    name: str
+    query: str | None = None
+    new_count: int | None = None
+    total_count: int | None = None
+    push_enabled: bool | None = None
+    push_available: bool | None = None
+
+
+### Search content listings ###
+
+
+class SearchContentPrice(BlocketBaseModel):
+    value: Any | None = None
+    suffix: str | None = None
+
+
+class SearchContentAd(BlocketBaseModel):
+    ad_id: str | None = None
+    list_id: str | None = None
+    subject: str | None = None
+    body: str | None = None
+    price: SearchContentPrice | None = None
+
+
+class SearchContentResult(BlocketBaseModel):
+    ad: SearchContentAd | None = None
+
+
+class SearchContentResults(BlocketBaseModel):
+    data: list[SearchContentResult]
+    total_count: int | None = None
+    total_page_count: int | None = None
+    timestamp: datetime.datetime | None = None
+
+
+### Price evaluation ###
+
+
+class PriceEvaluation(BlocketBaseModel):
+    registration_number: str | None = None
+    private_valuation: int | None = None
+
+
+### Home search ###
+
+
+class HomeSearchPoint(BlocketBaseModel):
+    lat: float | None = None
+    lon: float | None = None
+
+
+class HomeSearchLocation(BlocketBaseModel):
+    id: str | None = None
+    locality: str | None = None
+    countryCode: str | None = None
+    streetNumber: str | None = None
+    route: str | None = None
+    point: HomeSearchPoint | None = None
+
+
+class HomeSearchUpload(BlocketBaseModel):
+    id: str | None = None
+    order: int | None = None
+    type: str | None = None
+    url: str | None = None
+
+
+class HomeSearchDocument(BlocketBaseModel):
+    id: str | None = None
+    title: str | None = None
+    bedroomCount: int | None = None
+    roomCount: int | None = None
+    rent: int | None = None
+    currency: str | None = None
+    monthlyCost: int | None = None
+    homeType: str | None = None
+    location: HomeSearchLocation | None = None
+    uploads: list[HomeSearchUpload] | None = None
+
+
+class HomeSearchDocuments(BlocketBaseModel):
+    hasNextPage: bool | None = None
+    hasPreviousPage: bool | None = None
+    nodes: list[HomeSearchDocument] | None = None
+    pagesCount: int | None = None
+    totalCount: int | None = None
+
+
+class HomeIndexSearch(BlocketBaseModel):
+    documents: HomeSearchDocuments | None = None
+
+
+class HomeSearchData(BlocketBaseModel):
+    homeIndexSearch: HomeIndexSearch | None = None
+
+
+class HomeSearchResponse(BlocketBaseModel):
+    data: HomeSearchData | None = None


### PR DESCRIPTION
### Summary

- Added as_objects overloads for saved searches, saved-search listings, vehicle price evaluations, home search results, and store listings so these APIs can return typed responses. 

- Introduced flexible Pydantic models for saved searches, generic search content, price evaluations, and Qasa home search payloads to back the new object responses. 

- Expanded the search-related test suite to validate both dictionary and object responses for the newly supported endpoints. 

### Testing

✅ pytest 