### PR TITLE
Add as objects parameter to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,22 @@ Some calls require a `bearerToken`. However, some calls are public and don't req
 
 | Function  | Token required | `as_objects` | Description  |
 |---|---|---|---|
-| [`api.saved_searches()`](#saved_searches) | 🔐 Yes | - | List your saved searches (bevakningar)  |
-| [`api.get_listings()`](#get_listings) | 🔐 Yes | - | List items related to a saved search |
+| [`api.saved_searches()`](#saved_searches) | 🔐 Yes | Yes | List your saved searches (bevakningar)  |
+| [`api.get_listings()`](#get_listings) | 🔐 Yes | Yes | List items related to a saved search |
 | [`api.custom_search()`](#custom_search)  | 👏 No | Yes | Search for everything on Blocket and filter by region |
 | [`api.motor_search()`](#motor_search)  | 👏 No | Yes | Advanced search for car-listings. |
-| [`api.price_eval()`](#price_eval)  | 👏 No | - | Vehicle purchase valuation and details. | 
-| [`api.home_search()`](#home_search)  | 👏 No | - | Query home listings.
+| [`api.price_eval()`](#price_eval)  | 👏 No | Yes | Vehicle purchase valuation and details. |
+| [`api.home_search()`](#home_search)  | 👏 No | Yes | Query home listings.
 | [`api.store_search()`](#store_search)  | 👏 No | Yes | Search for a store.
-| [`api.get_store_listings()`](#get_store_listings)  | 👏 No | - | Get listings from a specific store.
+| [`api.get_store_listings()`](#get_store_listings)  | 👏 No | Yes | Get listings from a specific store.
 
 ## 🤓 Detailed usage
 
 ### saved_searches
 
 Saved searches are your so called "Bevakningar" and can be found [here](https://www.blocket.se/sparade/bevakningar). Each saved search has and unique `id` which can be used as a parameter to `get_listings()`, see below.
+
+- `as_objects` (`bool`, optional) - Return results as pydantic models, default is `False`.
 
 ```py
 >>> api.saved_searches()
@@ -79,6 +81,7 @@ Returns all listings related to a saved search.
 Parameters:
 - `search_id` (`int`, optional) - Get listings for a specific saved search. If not provided, all saved searches will be combined.
 - `limit` (`int`, optional) - Limit number of results returned, max is 99.
+- `as_objects` (`bool`, optional) - Return results as pydantic models, default is `False`.
 
 ```py
 >>> api.get_listings(4150081)
@@ -174,9 +177,10 @@ To query listings related to a specific car, supply the following parameters:
 ```
 
 ### price_eval
-Query price evaluation for a specific vehicle by using cars registration number (ABC123). This returns company and private estimated prices, car information, and more. The api queries same endpoint as Blockets ["värdera bil"](https://www.blocket.se/tjanster/vardera-bil) service. 
+Query price evaluation for a specific vehicle by using cars registration number (ABC123). This returns company and private estimated prices, car information, and more. The api queries same endpoint as Blockets ["värdera bil"](https://www.blocket.se/tjanster/vardera-bil) service.
 
 - `registration_number` (`str`, required) - Registration number of the vehicle.
+- `as_objects` (`bool`, optional) - Return results as pydantic models, default is `False`.
 ```py
 >>> api.price_eval("ABC123")
 {
@@ -195,11 +199,12 @@ Query price evaluation for a specific vehicle by using cars registration number 
 ### home_search
 Query home listings from [bostad.blocket.se](https://bostad.blocket.se/).
 
-- `city` (`str`, required) - City name, ex. Stockholm. 
+- `city` (`str`, required) - City name, ex. Stockholm.
 - `type` (`HomeType`, optional) - Type of home, ex. `HomeType.apartment`.
 - `order_by` (`OrderBy`, optional) - Sorting order, ex. `OrderBy.price`.
 - `ordering` (`HOME_SEARCH_ORDERING`, optional) - Sorting order, ex. `"descending"`.
 - `offset` (`int`, optional) - Offset for results, ex. `60`.
+- `as_objects` (`bool`, optional) - Return results as pydantic models, default is `False`.
 
 ```py
 >>> from blocket_api.qasa import HomeType, OrderBy
@@ -239,6 +244,7 @@ Get listings from a specific store.
 
 - `store_id` (`int`, required) - The store id. Can be obtained by calling `store_search()`.
 - `page` (`int`, optional) - The page number to return.
+- `as_objects` (`bool`, optional) - Return results as pydantic models, default is `False`.
 
 ```py
 >>> api.get_store_listings(1234)

--- a/blocket_api/models.py
+++ b/blocket_api/models.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 ### CustomSearch ###
 
@@ -49,6 +49,59 @@ class CustomSearchResult(BaseModel):
 class CustomSearchResults(BaseModel):
     data: list[CustomSearchResult]
     total_count: int
+
+
+### SavedSearch ###
+
+
+class SavedSearch(BaseModel):
+    id: str
+    name: str | None = None
+    query: str | None = None
+    new_count: int | None = None
+    total_count: int | None = None
+    push_enabled: bool | None = None
+    push_available: bool | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+### Listings ###
+
+
+class ListingPrice(BaseModel):
+    value: int | float | None = None
+    suffix: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ListingAd(BaseModel):
+    ad_id: str | None = None
+    ad_status: str | None = None
+    body: str | None = None
+    list_id: str | None = None
+    list_time: datetime.datetime | None = None
+    subject: str | None = None
+    zipcode: str | None = None
+    price: ListingPrice | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ListingEntry(BaseModel):
+    ad: ListingAd | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ListingResults(BaseModel):
+    data: list[ListingEntry]
+    total_count: int | None = None
+    timestamp: datetime.datetime | None = None
+    total_page_count: int | None = None
+
+    model_config = ConfigDict(extra="allow")
 
 
 ### MotorSearch ###
@@ -149,3 +202,114 @@ class StoreSearchResults(BaseModel):
     data: list[StoreSearchResult]
     total_count: int
     total_page_count: int
+
+
+### Price evaluation ###
+
+
+class PriceEvaluation(BaseModel):
+    registration_number: str
+    private_valuation: int | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+### Home search ###
+
+
+class HomeSearchUpload(BaseModel):
+    id: str | None = None
+    order: int | None = None
+    type: str | None = None
+    url: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchLocationPoint(BaseModel):
+    lat: float | None = None
+    lon: float | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchLocation(BaseModel):
+    id: str | None = None
+    locality: str | None = None
+    countryCode: str | None = None
+    streetNumber: str | None = None
+    point: HomeSearchLocationPoint | None = None
+    route: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchNode(BaseModel):
+    bedroomCount: int | None = None
+    blockListing: bool | None = None
+    rentalLengthSeconds: int | None = None
+    householdSize: int | None = None
+    corporateHome: bool | None = None
+    description: str | None = None
+    endDate: datetime.datetime | None = None
+    firstHand: bool | None = None
+    furnished: bool | None = None
+    homeType: str | None = None
+    id: str | None = None
+    instantSign: bool | None = None
+    market: str | None = None
+    lastBumpedAt: datetime.datetime | None = None
+    monthlyCost: int | None = None
+    petsAllowed: bool | None = None
+    platform: str | None = None
+    publishedAt: datetime.datetime | None = None
+    publishedOrBumpedAt: datetime.datetime | None = None
+    earlyAccessEndsAt: datetime.datetime | None = None
+    rent: int | None = None
+    currency: str | None = None
+    roomCount: int | None = None
+    seniorHome: bool | None = None
+    shared: bool | None = None
+    shortcutHome: bool | None = None
+    smokingAllowed: bool | None = None
+    sortingScore: float | None = None
+    squareMeters: int | None = None
+    startDate: datetime.datetime | None = None
+    studentHome: bool | None = None
+    tenantBaseFee: int | None = None
+    title: str | None = None
+    wheelchairAccessible: bool | None = None
+    location: HomeSearchLocation | None = None
+    displayStreetNumber: str | None = None
+    uploads: list[HomeSearchUpload] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchDocuments(BaseModel):
+    hasNextPage: bool | None = None
+    hasPreviousPage: bool | None = None
+    nodes: list[HomeSearchNode] | None = None
+    pagesCount: int | None = None
+    totalCount: int | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeIndexSearch(BaseModel):
+    documents: HomeSearchDocuments | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchData(BaseModel):
+    homeIndexSearch: HomeIndexSearch | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class HomeSearchResponse(BaseModel):
+    data: HomeSearchData | None = None
+    errors: list[dict] | None = None
+
+    model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
### Summary

- Introduced SavedSearch, generic listing, price evaluation, and home search Pydantic models to support object serialization across additional endpoints.

- Added as_objects overloads for saved_searches, get_listings, price_eval, home_search, and get_store_listings plus documentation updates describing the option.

- Extended the search tests to validate the new object responses for all affected APIs.

### Testing

✅ pytest

Fixes issue #13 