### PR TITLE
Add as_objects param for home_search

### DIFF
--- a/blocket_api/blocket.py
+++ b/blocket_api/blocket.py
@@ -11,6 +11,7 @@ import httpx
 
 from blocket_api.models import (
     CustomSearchResults,
+    HomeSearchResults,
     MotorSearchResults,
     StoreSearchResults,
 )
@@ -403,6 +404,7 @@ class BlocketAPI:
         url = f"{BYTBIL_URL}/blocket-basedata-api/v3/vehicle-data/{registration_number}"
         return _make_request(url=f"{url}", token=None).json()
 
+    @overload
     def home_search(
         self,
         city: str,
@@ -410,19 +412,45 @@ class BlocketAPI:
         order_by: OrderBy = OrderBy.published_at,
         ordering: HOME_SEARCH_ORDERING = "descending",
         offset: int = 0,
-    ) -> dict:
+        *,
+        as_objects: Literal[True],
+    ) -> HomeSearchResults: ...
+
+    @overload
+    def home_search(
+        self,
+        city: str,
+        type: HomeType,
+        order_by: OrderBy = OrderBy.published_at,
+        ordering: HOME_SEARCH_ORDERING = "descending",
+        offset: int = 0,
+        *,
+        as_objects: Literal[False] = False,
+    ) -> dict: ...
+
+    def home_search(
+        self,
+        city: str,
+        type: HomeType,
+        order_by: OrderBy = OrderBy.published_at,
+        ordering: HOME_SEARCH_ORDERING = "descending",
+        offset: int = 0,
+        *,
+        as_objects: bool = False,
+    ) -> dict | HomeSearchResults:
         """
         This returns all available home listings available at
         https://bostad.blocket.se/. Specify offset to get next page. Each page contains
         60 items, which is max items returned per api query.
         """
-        return Qasa(
+        response = Qasa(
             city=city,
             home_type=type,
             order_by=order_by,
             ordering=ordering,
             offset=offset,
         ).search()
+        return HomeSearchResults.model_validate(response) if as_objects else response
 
     @overload
     def search_store(

--- a/blocket_api/models.py
+++ b/blocket_api/models.py
@@ -149,3 +149,87 @@ class StoreSearchResults(BaseModel):
     data: list[StoreSearchResult]
     total_count: int
     total_page_count: int
+
+
+### HomeSearch ###
+
+
+class HomeSearchGeoPoint(BaseModel):
+    lat: float
+    lon: float
+
+
+class HomeSearchLocation(BaseModel):
+    id: int
+    locality: str
+    countryCode: str
+    streetNumber: str | None = None
+    point: HomeSearchGeoPoint
+    route: str
+
+
+class HomeSearchUpload(BaseModel):
+    id: int
+    order: int | None = None
+    type: str
+    url: str
+
+
+class HomeSearchResult(BaseModel):
+    bedroomCount: int | None = None
+    blockListing: bool
+    rentalLengthSeconds: float | None = None
+    householdSize: int
+    corporateHome: bool
+    description: str
+    endDate: str | None = None
+    firstHand: bool
+    furnished: bool
+    homeType: str
+    id: str
+    instantSign: bool
+    market: str
+    lastBumpedAt: str | None = None
+    monthlyCost: int
+    petsAllowed: bool
+    platform: str
+    publishedAt: str
+    publishedOrBumpedAt: str
+    earlyAccessEndsAt: str | None = None
+    rent: int
+    currency: str
+    roomCount: int
+    seniorHome: bool
+    shared: bool
+    shortcutHome: bool
+    smokingAllowed: bool
+    sortingScore: float
+    squareMeters: int
+    startDate: str
+    studentHome: bool
+    tenantBaseFee: int
+    title: str | None = None
+    wheelchairAccessible: bool
+    location: HomeSearchLocation
+    displayStreetNumber: bool
+    uploads: list[HomeSearchUpload]
+
+
+class Documents(BaseModel):
+    hasNextPage: bool
+    hasPreviousPage: bool
+    nodes: list[HomeSearchResult]
+    pagesCount: int
+    totalCount: int
+
+
+class HomeIndexSearch(BaseModel):
+    documents: Documents
+
+
+class DataModel(BaseModel):
+    homeIndexSearch: HomeIndexSearch
+
+
+class HomeSearchResults(BaseModel):
+    data: DataModel

--- a/tests/searches.py
+++ b/tests/searches.py
@@ -10,6 +10,14 @@ from blocket_api.models import (
     CustomSearchPrice,
     CustomSearchResult,
     CustomSearchResults,
+    DataModel,
+    Documents,
+    HomeIndexSearch,
+    HomeSearchGeoPoint,
+    HomeSearchLocation,
+    HomeSearchResult,
+    HomeSearchResults,
+    HomeSearchUpload,
     MotorSearchCar,
     MotorSearchCarEquipment,
     MotorSearchCarImage,
@@ -352,27 +360,183 @@ def test_price_eval() -> None:
     }
 
 
-@respx.mock
-def test_home_search() -> None:
-    respx.post(f"{QASA_URL}").mock(
-        return_value=Response(
-            status_code=200,
-            json={
-                "bedroomCount": "2",
-                "rent": 9500,
-                "petsAllowed": False,
-            },
-        ),
-    )
-    assert api.home_search(
-        city="Stockholm",
-        type=HomeType.apartment,
-        order_by=OrderBy.price,
-    ) == {
-        "bedroomCount": "2",
-        "rent": 9500,
-        "petsAllowed": False,
-    }
+class Test_HomeSearch:
+    @respx.mock
+    def test_home_search(self) -> None:
+        respx.post(f"{QASA_URL}").mock(
+            return_value=Response(
+                status_code=200,
+                json={
+                    "bedroomCount": "2",
+                    "rent": 9500,
+                    "petsAllowed": False,
+                },
+            ),
+        )
+        assert api.home_search(
+            city="Stockholm",
+            type=HomeType.apartment,
+            order_by=OrderBy.price,
+        ) == {
+            "bedroomCount": "2",
+            "rent": 9500,
+            "petsAllowed": False,
+        }
+
+    @respx.mock
+    def test_home_search_as_objects(self) -> None:
+        respx.post(f"{QASA_URL}").mock(
+            return_value=Response(
+                status_code=200,
+                json={
+                    "data": {
+                        "homeIndexSearch": {
+                            "documents": {
+                                "hasNextPage": True,
+                                "hasPreviousPage": False,
+                                "nodes": [
+                                    {
+                                        "bedroomCount": None,
+                                        "blockListing": False,
+                                        "rentalLengthSeconds": None,
+                                        "householdSize": 2,
+                                        "corporateHome": False,
+                                        "description": "Charmig och rymlig 1:a med stor balkong",
+                                        "endDate": None,
+                                        "firstHand": False,
+                                        "furnished": True,
+                                        "homeType": "apartment",
+                                        "id": "1205500",
+                                        "instantSign": False,
+                                        "market": "sweden",
+                                        "lastBumpedAt": None,
+                                        "monthlyCost": 12184,
+                                        "petsAllowed": False,
+                                        "platform": "qasa",
+                                        "publishedAt": "2025-09-22T16:20:08Z",
+                                        "publishedOrBumpedAt": "2025-09-22T16:20:08Z",
+                                        "earlyAccessEndsAt": None,
+                                        "rent": 11500,
+                                        "currency": "SEK",
+                                        "roomCount": 1,
+                                        "seniorHome": False,
+                                        "shared": False,
+                                        "shortcutHome": False,
+                                        "smokingAllowed": False,
+                                        "sortingScore": 8.351962081128748,
+                                        "squareMeters": 33,
+                                        "startDate": "2025-11-01T00:00:00+00:00",
+                                        "studentHome": False,
+                                        "tenantBaseFee": 684,
+                                        "title": None,
+                                        "wheelchairAccessible": False,
+                                        "location": {
+                                            "id": 3137542,
+                                            "locality": "Bromma",
+                                            "countryCode": "SE",
+                                            "streetNumber": None,
+                                            "point": {
+                                                "lat": 1.338915,
+                                                "lon": 1.9352853,
+                                                "__typename": "GeoPoint",
+                                            },
+                                            "route": "Snörmakarvägen",
+                                            "__typename": "HomeDocumentLocationType",
+                                        },
+                                        "displayStreetNumber": False,
+                                        "uploads": [
+                                            {
+                                                "id": 17216695,
+                                                "order": 11,
+                                                "type": "home_picture",
+                                                "url": "https://image.here/image.jpg",
+                                                "__typename": "HomeDocumentUploadType",
+                                            },
+                                        ],
+                                        "__typename": "HomeDocument",
+                                    }
+                                ],
+                                "pagesCount": 25,
+                                "totalCount": 1442,
+                                "__typename": "HomeDocumentOffsetLimit",
+                            },
+                            "__typename": "HomeIndexSearchQuery",
+                        }
+                    }
+                },
+            ),
+        )
+        assert api.home_search(
+            city="Stockholm", type=HomeType.apartment, as_objects=True
+        ) == HomeSearchResults(
+            data=DataModel(
+                homeIndexSearch=HomeIndexSearch(
+                    documents=Documents(
+                        hasNextPage=True,
+                        hasPreviousPage=False,
+                        nodes=[
+                            HomeSearchResult(
+                                bedroomCount=None,
+                                blockListing=False,
+                                rentalLengthSeconds=None,
+                                householdSize=2,
+                                corporateHome=False,
+                                description="Charmig och rymlig 1:a med stor balkong",
+                                endDate=None,
+                                firstHand=False,
+                                furnished=True,
+                                homeType="apartment",
+                                id="1205500",
+                                instantSign=False,
+                                market="sweden",
+                                lastBumpedAt=None,
+                                monthlyCost=12184,
+                                petsAllowed=False,
+                                platform="qasa",
+                                publishedAt="2025-09-22T16:20:08Z",
+                                publishedOrBumpedAt="2025-09-22T16:20:08Z",
+                                earlyAccessEndsAt=None,
+                                rent=11500,
+                                currency="SEK",
+                                roomCount=1,
+                                seniorHome=False,
+                                shared=False,
+                                shortcutHome=False,
+                                smokingAllowed=False,
+                                sortingScore=8.351962081128748,
+                                squareMeters=33,
+                                startDate="2025-11-01T00:00:00+00:00",
+                                studentHome=False,
+                                tenantBaseFee=684,
+                                title=None,
+                                wheelchairAccessible=False,
+                                location=HomeSearchLocation(
+                                    id=3137542,
+                                    locality="Bromma",
+                                    countryCode="SE",
+                                    streetNumber=None,
+                                    point=HomeSearchGeoPoint(
+                                        lat=1.338915, lon=1.9352853
+                                    ),
+                                    route="Snörmakarvägen",
+                                ),
+                                displayStreetNumber=False,
+                                uploads=[
+                                    HomeSearchUpload(
+                                        id=17216695,
+                                        order=11,
+                                        type="home_picture",
+                                        url="https://image.here/image.jpg",
+                                    )
+                                ],
+                            )
+                        ],
+                        pagesCount=25,
+                        totalCount=1442,
+                    )
+                )
+            )
+        )
 
 
 class Test_StoreSearch:


### PR DESCRIPTION
This makes it possible to use `as_objects` param for `home_search()`. 

A part of #13.