### PR TITLE
feat: Add color param to motor_search

### DIFF
--- a/blocket_api/blocket.py
+++ b/blocket_api/blocket.py
@@ -130,6 +130,7 @@ CHASSI_OPTIONS = Literal[
     "Kombi", "SUV", "Sedan", "Halvkombi", "Coupé", "Cab", "Familjebuss", "Yrkesfordon"
 ]
 GEARBOX_OPTIONS = Literal["Automat", "Manuell"]
+COLOR_OPTIONS = Literal["Blå", "Brun", "Grå", "Grön", "Gul", "Röd", "Svart", "Vit"]
 
 
 class APIError(Exception): ...
@@ -352,6 +353,7 @@ class BlocketAPI:
         modelYear: Optional[Tuple[int, int]] = None,
         milage: Optional[Tuple[int, int]] = None,
         gearbox: Optional[GEARBOX_OPTIONS] = None,
+        color: Optional[List[COLOR_OPTIONS]] = None,
         *,
         as_objects: Literal[False] = False,
     ) -> dict: ...
@@ -367,6 +369,7 @@ class BlocketAPI:
         modelYear: Optional[Tuple[int, int]] = None,
         milage: Optional[Tuple[int, int]] = None,
         gearbox: Optional[GEARBOX_OPTIONS] = None,
+        color: Optional[List[COLOR_OPTIONS]] = None,
         *,
         as_objects: bool = False,
     ) -> Union[dict, MotorSearchResults]: ...
@@ -382,6 +385,7 @@ class BlocketAPI:
         modelYear: Optional[Tuple[int, int]] = None,
         milage: Optional[Tuple[int, int]] = None,
         gearbox: Optional[GEARBOX_OPTIONS] = None,
+        color: Optional[List[COLOR_OPTIONS]] = None,
         *,
         as_objects: bool = False,
     ) -> dict | MotorSearchResults:

--- a/tests/searches.py
+++ b/tests/searches.py
@@ -302,13 +302,20 @@ class Test_CustomSearch:
 class Test_MotorSearchURLs:
     @respx.mock
     def test_make_filter(self) -> None:
-        expected_url_filter = '?filter={"key": "make", "values": ["Audi", "Toyota"]}'
+        expected_url_filter = (
+            '?filter={"key": "make", "values": ["Audi", "Toyota"]}'
+            '&filter={"key": "color", "values": ["Blå", "Röd"]}'
+        )
         respx.get(
             f"{BASE_URL}/motor-search-service/v4/search/car{expected_url_filter}&page=1"
         ).mock(
             return_value=Response(status_code=200, json={"data": "ok"}),
         )
-        assert api.motor_search(page=1, make=["Audi", "Toyota"]) == {"data": "ok"}
+        assert api.motor_search(
+            page=1,
+            make=["Audi", "Toyota"],
+            color=["Blå", "Röd"],
+        ) == {"data": "ok"}
 
     @respx.mock
     def test_motor_search_as_objects(self) -> None:


### PR DESCRIPTION
Make it possible to filter motor_search by color.

This was requested by @ChethiyaKD in https://github.com/dunderrrrrr/blocket_api/pull/27, but since no further activity in that PR I'm creating a new one.