### PR TITLE
feat: add org/dealer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ api.search_car(
     price_to=50000,
     transmissions=[CarTransmission.MANUAL],
     locations=[Location.STOCKHOLM],
+    org_id=1337, # dealer or store id
 )
 
 # search for boats
@@ -66,6 +67,7 @@ api.search_boat(
     length_to=15,    
     price_from=20000,
     price_to=90000,
+    org_id=1337, # dealer or store id
 )
 
 # search for motorcycles
@@ -80,6 +82,7 @@ api.search_mc(
     price_to=90000,
     engine_volume_from=100,
     engine_volume_to=200,
+    org_id=1337, # dealer or store id
 )
 
 

--- a/blocket_api/blocket.py
+++ b/blocket_api/blocket.py
@@ -88,6 +88,7 @@ class BlocketAPI:
         milage_to: int | None = None,
         colors: list[CarColor] = [],
         transmissions: list[CarTransmission] = [],
+        org_id: int | None = None,
     ) -> dict[str, Any]:
         url = f"{SITE_URL}/mobility/search/api/search/SEARCH_ID_CAR_USED"
 
@@ -101,6 +102,7 @@ class BlocketAPI:
             "year_to": year_to,
             "milage_from": milage_from,
             "milage_to": milage_to,
+            "org_id": org_id,
         }
 
         params = [QueryParam(k, v) for k, v in param_dict.items() if v is not None]
@@ -125,6 +127,7 @@ class BlocketAPI:
         price_to: int | None = None,
         length_from: int | None = None,
         length_to: int | None = None,
+        org_id: int | None = None,
     ) -> Any:
         url = f"{SITE_URL}/mobility/search/api/search/SEARCH_ID_BOAT_USED"
 
@@ -136,6 +139,7 @@ class BlocketAPI:
             "price_to": price_to,
             "length_feet_from": length_from,
             "length_feet_to": length_to,
+            "org_id": org_id,
         }
 
         params = [QueryParam(k, v) for k, v in param_dict.items() if v is not None]
@@ -158,6 +162,7 @@ class BlocketAPI:
         price_to: int | None = None,
         engine_volume_from: int | None = None,
         engine_volume_to: int | None = None,
+        org_id: int | None = None,
     ) -> dict[str, Any]:
         url = f"{SITE_URL}/mobility/search/api/search/SEARCH_ID_MC_USED"
 
@@ -169,6 +174,7 @@ class BlocketAPI:
             "price_to": price_to,
             "engine_volume_from": engine_volume_from,
             "engine_volume_to": engine_volume_to,
+            "org_id": org_id,
         }
 
         params = [QueryParam(k, v) for k, v in param_dict.items() if v is not None]

--- a/tests/requests.py
+++ b/tests/requests.py
@@ -123,6 +123,7 @@ class Test_SearchCar:
             "&price_from=1000"
             "&price_to=50000"
             "&transmission=2"
+            "&org_id=1337"
         )
         respx.get(expected_url).mock(
             return_value=httpx.Response(200, json={"status": "ok"})
@@ -133,6 +134,7 @@ class Test_SearchCar:
             price_from=1000,
             price_to=50000,
             transmissions=[CarTransmission.AUTOMATIC],
+            org_id=1337,
         )
         assert result == {"status": "ok"}
 
@@ -151,6 +153,7 @@ class Test_SearchBoat:
             "&price_to=90000"
             "&length_feet_from=10"
             "&length_feet_to=15"
+            "&org_id=1337"
         )
         respx.get(expected_url).mock(
             return_value=httpx.Response(200, json={"status": "ok"})
@@ -163,13 +166,14 @@ class Test_SearchBoat:
             length_to=15,
             price_from=20000,
             price_to=90000,
+            org_id=1337,
         )
         assert result == {"status": "ok"}
 
 
 class Test_McSearch:
     @respx.mock
-    def test_search_boat(self) -> None:
+    def test_search_mc(self) -> None:
         expected_url = (
             f"{SITE_URL}/mobility/search/api/search/SEARCH_ID_MC_USED"
             "?q=snabb"
@@ -182,6 +186,7 @@ class Test_McSearch:
             "&make=1484"
             "&location=0.300001"
             "&type=11"
+            "&org_id=1337"
         )
         respx.get(expected_url).mock(
             return_value=httpx.Response(200, json={"status": "ok"})
@@ -195,6 +200,7 @@ class Test_McSearch:
             price_to=90000,
             engine_volume_from=10,
             engine_volume_to=15,
+            org_id=1337,
         )
         assert result == {"status": "ok"}
 


### PR DESCRIPTION
This makes it possible to filter for a specific org id (a store).

The id can be found in the address bar when browsing for example `https://www.blocket.se/mobility/search/mc?orgId=XXXXXXX`.

Closes https://github.com/dunderrrrrr/blocket_api/issues/48