### PR TITLE
fix: updated attribute order in description section class

### DIFF
--- a/blocket_api/ad_parser.py
+++ b/blocket_api/ad_parser.py
@@ -91,7 +91,7 @@ class MobilityAd:
                 data["price"] = price_elem.get_text(strip=True)
 
     def _extract_description(self, grid: Tag, data: dict) -> None:
-        for section in grid.find_all("section", class_="border-t mt-40 pt-40"):
+        for section in grid.find_all("section", class_="pt-40 border-t mt-40"):
             h2 = section.find("h2", class_="t3 mb-0")
             if h2 and "beskrivning" in h2.get_text(strip=True).lower():
                 desc_div = section.find("div", class_="whitespace-pre-wrap")

--- a/tests/requests.py
+++ b/tests/requests.py
@@ -243,7 +243,7 @@ class Test_GetAd:
                     <span class="t2">389 000 kr</span>
                 </div>
 
-                <section class="border-t mt-40 pt-40">
+                <section class="pt-40 border-t mt-40">
                     <h2 class="t3 mb-0">Beskrivning</h2>
                     <div class="whitespace-pre-wrap">Mycket fin bil i nyskick.</div>
                 </section>
@@ -311,7 +311,7 @@ class Test_GetAd:
                     <span class="t2">110 000 kr</span>
                 </div>
 
-                <section class="border-t mt-40 pt-40">
+                <section class="pt-40 border-t mt-40">
                     <h2 class="t3 mb-0">Beskrivning</h2>
                     <div class="whitespace-pre-wrap">Snabb båge</div>
                 </section>


### PR DESCRIPTION
Blocket changed the order of the attributes in the section tags for the description field. 

Before:
`<section class="border-t pt-40 mt-40">`
Now:
`<section class="pt-40 border-t mt-40">`

This fix changes the `_extract_description` method to reflect this change. 